### PR TITLE
fix: update pypa/gh-action-pypi-publish to v1.14.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,7 @@ jobs:
             dist/*
 
       - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0 # v1.9.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           attestations: true
 


### PR DESCRIPTION
## Summary
- Updates `pypa/gh-action-pypi-publish` from v1.9.0 to v1.14.0
- Fixes publish failure on v0.8.2 tag: old action didn't support `attestations` input and couldn't parse Metadata-Version 2.4 from `uv build` output

## Test plan
- [ ] CI passes
- [ ] Next tag push publishes to PyPI successfully