### PR TITLE
fix: remove broken SLSA provenance job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,9 +53,6 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
-    outputs:
-      hashes: ${{ steps.hash.outputs.hashes }}
-
     permissions:
       id-token: write
       contents: write
@@ -73,11 +70,6 @@ jobs:
 
       - name: Check package
         run: uvx twine check dist/*
-
-      - name: Generate subject hashes
-        id: hash
-        run: |
-          cd dist && echo "hashes=$(sha256sum * | base64 -w0)" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
@@ -110,15 +102,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           attestations: true
-
-  provenance:
-    needs: publish
-    if: startsWith(github.ref, 'refs/tags/v')
-    permissions:
-      actions: read
-      id-token: write
-      contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
-    with:
-      base64-subjects: ${{ needs.publish.outputs.hashes }}
-      upload-assets: true


### PR DESCRIPTION
## Summary
- Removes the `provenance` job (slsa-github-generator v2.1.0) which fails with a false-positive private repo detection
- The generator also uses deprecated Node.js 20 actions that will stop working June 2026
- PyPI trusted publishing with attestations (already configured) provides equivalent supply chain security

## Test plan
- [ ] CI passes
- [ ] Next tag publish completes without the provenance failure